### PR TITLE
refactor expenses into a custom hook

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -46,32 +46,17 @@ export const useAnnualIncome = (
     control,
   });
 
-  const annualIncome = 12 * units.reduce((acc, cur) => acc + Number(cur.monthlyRent), 0)
-  return annualIncome
+  const annualIncome =
+    12 * units.reduce((acc, cur) => acc + Number(cur.monthlyRent), 0);
+  return annualIncome;
 };
 
-export interface UseAnalyticsResponse {
-  monthlyCashFlow: number;
-  cocReturn: number;
-}
-
-export const useAnalytics = (
+export const useAnnualExpenses = (
   control: Control<FormValues, any, FormValues>
-): UseAnalyticsResponse => {
+): number => {
   const annualIncome = useAnnualIncome(control);
   const monthlyIncome = annualIncome / 12;
-
   const monthlyMortgagePayment = useMonthlyMortgagePayment(control);
-  const purchasePrice = useWatch({
-    name: "purchasePrice",
-    control,
-  });
-  const downPaymentPercentage =
-    useWatch({
-      name: "downPayment",
-      control,
-    }) * 0.01;
-  const totalCashInvested = downPaymentPercentage * purchasePrice; // todo - there are usually other costs like renovation costs, closing costs, etc.
   const monthlyPropertyTax =
     useWatch({
       name: "annualPropertyTax",
@@ -116,6 +101,34 @@ export const useAnalytics = (
     monthlyMaintenance +
     monthlyCapex +
     monthlyUtilities;
+
+  const annualExpenses = monthlyExpenses * 12;
+  return annualExpenses;
+};
+
+export interface UseAnalyticsResponse {
+  monthlyCashFlow: number;
+  cocReturn: number;
+}
+
+export const useAnalytics = (
+  control: Control<FormValues, any, FormValues>
+): UseAnalyticsResponse => {
+  const annualIncome = useAnnualIncome(control);
+  const monthlyIncome = annualIncome / 12;
+
+  const purchasePrice = useWatch({
+    name: "purchasePrice",
+    control,
+  });
+  const downPaymentPercentage =
+    useWatch({
+      name: "downPayment",
+      control,
+    }) * 0.01;
+  const totalCashInvested = downPaymentPercentage * purchasePrice; // todo - there are usually other costs like renovation costs, closing costs, etc.
+  const annualExpenses = useAnnualExpenses(control)
+  const monthlyExpenses = annualExpenses / 12;
 
   const monthlyCashFlow = roundTwoDecimalPlaces(
     monthlyIncome - monthlyExpenses


### PR DESCRIPTION
Cleaning up the code a bit to set up for further analytics calculations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors expense calculations into a reusable hook and simplifies analytics logic.
> 
> - Introduces `useAnnualExpenses` to compute annual expenses from `mortgage`, `propertyTax`, `insurance`, `vacancyRate`, `maintenanceRate`, `capexRate`, and `utilities` based on form values in `src/hooks/index.ts`
> - Updates `useAnalytics` to use `useAnnualIncome` and `useAnnualExpenses` to derive `monthlyCashFlow` and `cocReturn`, removing inlined expense math while retaining `totalCashInvested` computation
> - Minor formatting cleanups in `useAnnualIncome`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 961fd692c9f7fc4ebe02bf18ec860436f988312e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->