### PR TITLE
add custom hook for calculating cash flow over the yearly loan period

### DIFF
--- a/src/components/Analysis.tsx
+++ b/src/components/Analysis.tsx
@@ -1,4 +1,4 @@
-import { useAnalytics } from "@/hooks";
+import { useAnalytics, useLongTermCashflow } from "@/hooks";
 import type { FormValues } from "@/types/shared";
 import { useWatch, type Control } from "react-hook-form";
 
@@ -8,10 +8,7 @@ interface AnalysisProps {
 
 const Analysis = ({ control }: AnalysisProps) => {
   const { monthlyCashFlow, cocReturn } = useAnalytics(control);
-
-  // todo - remove, used for debugging
-  const formValues = useWatch({ control });
-  console.log(formValues)
+  const longTermCashflow = useLongTermCashflow(control);
 
   return (
     <>

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,8 +1,9 @@
 import {
+  buildCashflowForLoanPeriod,
   calculateMonthlyMortgagePayment,
   roundTwoDecimalPlaces,
 } from "@/lib/utils";
-import type { FormValues } from "@/types/shared";
+import type { CashflowLineChartMetadata, FormValues } from "@/types/shared";
 import { useWatch, type Control } from "react-hook-form";
 
 export const useMonthlyMortgagePayment = (
@@ -127,7 +128,7 @@ export const useAnalytics = (
       control,
     }) * 0.01;
   const totalCashInvested = downPaymentPercentage * purchasePrice; // todo - there are usually other costs like renovation costs, closing costs, etc.
-  const annualExpenses = useAnnualExpenses(control)
+  const annualExpenses = useAnnualExpenses(control);
   const monthlyExpenses = annualExpenses / 12;
 
   const monthlyCashFlow = roundTwoDecimalPlaces(
@@ -137,4 +138,33 @@ export const useAnalytics = (
     ((12 * monthlyCashFlow) / totalCashInvested) * 100
   );
   return { monthlyCashFlow, cocReturn };
+};
+
+export const useLongTermCashflow = (
+  control: Control<FormValues, any, FormValues>
+): CashflowLineChartMetadata[] => {
+  const annualIncome = useAnnualIncome(control);
+  const annualExpenses = useAnnualExpenses(control);
+  const loanTermInYears = useWatch({
+    name: "loanTerm",
+    control,
+  });
+  const annualRentGrowth =
+    useWatch({
+      name: "annualRentGrowth",
+      control,
+    }) * 0.01;
+  const annualOperatingExpenseIncrease =
+    useWatch({
+      name: "annualOperatingExpenseIncrease",
+      control,
+    }) * 0.01;
+    
+  return buildCashflowForLoanPeriod(
+    annualIncome,
+    annualExpenses,
+    loanTermInYears,
+    annualRentGrowth,
+    annualOperatingExpenseIncrease
+  );
 };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,4 +1,8 @@
-import type { FormValues, Unit } from "@/types/shared";
+import type {
+  CashflowLineChartMetadata,
+  FormValues,
+  Unit,
+} from "@/types/shared";
 import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
 
@@ -34,7 +38,7 @@ export const getDefaultValuesFromUrl = (): FormValues => {
     units,
     annualRentGrowth: 0,
     annualAppreciation: 0,
-    annualOperatingExpenseIncrease: 0
+    annualOperatingExpenseIncrease: 0,
   };
 };
 
@@ -80,4 +84,33 @@ export const calculateMonthlyMortgagePayment = (
 
   // round to two decimal places
   return roundTwoDecimalPlaces(monthlyPayment);
+};
+
+export const buildCashflowForLoanPeriod = (
+  startingIncome: number,
+  startingExpenses: number,
+  loanPeriod: number,
+  annualRentGrowth: number,
+  annualOperatingExpenseIncrease: number
+): CashflowLineChartMetadata[] => {
+  const firstYearCashFlow: CashflowLineChartMetadata = {
+    income: startingIncome,
+    expenses: startingExpenses,
+    cashFlow: startingIncome - startingExpenses
+  }
+  const cashflowOverTime: CashflowLineChartMetadata[] = [firstYearCashFlow]
+
+  for(let i = 0; i < loanPeriod - 1; i++) {
+    const prevYearMetaData = cashflowOverTime[cashflowOverTime.length - 1]
+    const curYearIncome = prevYearMetaData.income + (prevYearMetaData.income * annualRentGrowth)
+    const curYearExpenses = prevYearMetaData.expenses + (prevYearMetaData.expenses * annualOperatingExpenseIncrease)
+    const curYearCashflow = curYearIncome - curYearExpenses
+    cashflowOverTime.push({
+      income: curYearIncome,
+      expenses: curYearExpenses,
+      cashFlow: curYearCashflow
+    })
+  }
+
+  return cashflowOverTime
 };

--- a/src/types/shared/index.ts
+++ b/src/types/shared/index.ts
@@ -25,3 +25,9 @@ export type FormValues = {
   annualAppreciation: number;
   annualOperatingExpenseIncrease: number;
 };
+
+export type CashflowLineChartMetadata = {
+  income: number;
+  expenses: number;
+  cashFlow: number;
+};


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds long-term cashflow projections to analytics.
> 
> - New `useLongTermCashflow` hook computes yearly cashflow over `loanTerm` using `annualRentGrowth` and `annualOperatingExpenseIncrease`, leveraging `buildCashflowForLoanPeriod`
> - Adds `buildCashflowForLoanPeriod` in `lib/utils` to produce `CashflowLineChartMetadata[]` (income, expenses, cashFlow)
> - Introduces `CashflowLineChartMetadata` type in `types/shared`
> - Wires hook into `Analysis` and removes debug code
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ee17d26c615747b6e6f136a1ec03b42b184c1db. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->