### PR TITLE
clean up income projections form styling

### DIFF
--- a/src/components/forms/IncomeProjections.tsx
+++ b/src/components/forms/IncomeProjections.tsx
@@ -39,21 +39,23 @@ const IncomeProjections = ({ register, control }: IncomeProjectionsProps) => {
         <FieldLegend>Income projections</FieldLegend>
         <FieldGroup>
           {fields.map((unit, index) => (
-            <Field key={unit.id}>
-              <FieldLabel htmlFor={`units.${index}.monthlyRent`}>
-                {unit.name}
-              </FieldLabel>
-              <Input
-                type="number"
-                {...register(`units.${index}.monthlyRent`)}
-              />
-              <Button onClick={() => handleDeleteUnit(index)}>
+            <Field key={unit.id} className="flex flex-row">
+              <div>
+                <FieldLabel htmlFor={`units.${index}.monthlyRent`}>
+                  {unit.name}
+                </FieldLabel>
+                <Input
+                  type="number"
+                  {...register(`units.${index}.monthlyRent`)}
+                />
+              </div>
+              <Button className="max-w-max self-end" variant="ghost" onClick={() => handleDeleteUnit(index)}>
                 <Trash />
               </Button>
             </Field>
           ))}
         </FieldGroup>
-        <Button onClick={handleAddUnit}>
+        <Button className="max-w-max" onClick={handleAddUnit}>
           Add unit <Plus />
         </Button>
         <p>${annualIncome} annually</p>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refines layout and styling of `IncomeProjections` form.
> 
> - Wraps each unit `Field` in a flex row and groups label/input to align with a trailing delete button
> - Converts delete `Button` to `variant="ghost"` and aligns it to bottom-right with `self-end`; constrains width with `max-w-max`
> - Adds `max-w-max` to the "Add unit" button
> 
> No business logic changes; only UI/layout adjustments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 61c59c3cf4aa91a185d467c5999be6e473f44128. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->